### PR TITLE
Use configured chain id

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -51,6 +51,11 @@ func GetAuthPassword() string {
 	return viper.GetString("auth.password")
 }
 
+// GetChainID returns the configured chain ID
+func GetChainID() string {
+	return viper.GetString("chainId")
+}
+
 // InitConfig initializes the application configuration using viper.
 // If configPath is provided, it will use that specific file,
 // otherwise it will look for 'local.yaml' in the config directory

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -121,8 +121,8 @@ func (s *Server) Shutdown(ctx context.Context) error {
 
 // getTokenInfo handles the token info endpoint
 func (s *Server) getTokenInfo(c *fiber.Ctx) error {
-	chainId := c.Params("chainId")
 	tokenAddress := c.Params("tokenAddress")
+	chainId := config.GetChainID()
 
 	// Normalize address to lowercase to match stored format
 	tokenAddress = strings.ToLower(tokenAddress)

--- a/internal/server/templates/token-management.html
+++ b/internal/server/templates/token-management.html
@@ -496,8 +496,6 @@
                 </div>
                 
                 <form id="tokenForm">
-                    <input type="hidden" id="chainId" name="chainId" value="1313161575">
-                    
                     <div class="form-grid">
                         <div class="form-group">
                             <label for="tokenAddress">Token Address *</label>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Centralized chain configuration for token operations, removing the need to specify chain ID manually.
* **UI**
  * Removed the chain ID field from the “Add New Token” form; users no longer enter or submit chain ID.
* **Refactor**
  * Server now derives chain ID from configuration when fetching token info, simplifying requests and improving consistency.
  * Note: Any custom scripts relying on the removed form field for chain ID should be updated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->